### PR TITLE
Add an optional parameter to output the waveform data to the console

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ There are also some less-nifty options:
     -q will generate your waveform without printing out a bunch of stuff.
     -h will print out a help screen with all this info.
     -F will automatically overwrite destination file.
+    -o will output your waveform data to the console.
 
 Usage in code
 =============

--- a/bin/waveformjson
+++ b/bin/waveformjson
@@ -21,7 +21,7 @@ optparse = OptionParser.new do |o|
   end
 
   options[:force] = false
-  o.on("-F", "--force", "Force generationg of waveform if file exists") do
+  o.on("-F", "--force", "Force generation of waveform if file exists") do
     options[:force] = true
   end
 

--- a/bin/waveformjson
+++ b/bin/waveformjson
@@ -25,6 +25,12 @@ optparse = OptionParser.new do |o|
     options[:force] = true
   end
 
+  options[:output] = false
+  o.on("-o", "--output", "Output waveform data") do
+    options[:logger] = nil
+    options[:output] = true
+  end
+
   o.on("-h", "--help", "Display this screen") do
     puts o
     exit
@@ -34,26 +40,35 @@ end
 optparse.parse!
 
 begin
-  output = ARGV[1] || "waveform.json"
+  samples = Waveformjson.generate(ARGV[0], options)
 
-  if File.exists?(output) && !options[:force]
-    raise RuntimeError.new("Destination file #{output} exists. Use --force if you want to automatically remove it.")
+  json = "["
+
+  samples.each_with_index do |d, index|
+    json << d.to_s
+    json << ", " unless index == samples.size - 1
   end
 
-  json = Waveformjson.generate(ARGV[0], options)
-  File.open(output, 'w') do |f|
-    f << '['
+  json << "]"
 
-    json.each_with_index do |d, index|
-      f << d
-      f << ', ' unless index == json.size - 1
+  if options[:output]
+    print json
+  else
+    filename = ARGV[1] || "waveform.json"
+
+    if File.exists?(filename) && !options[:force]
+      raise RuntimeError.new("Destination file #{filename} exists. Use --force if you want to automatically remove it.")
     end
 
-    f << ']'
+    File.open(filename, "w") do |f|
+      f << json
+    end
   end
 rescue ArgumentError => e
   puts e.message + "\n\n"
   puts optparse
+  exit 1
 rescue RuntimeError => e
   puts e.message
+  exit 1
 end


### PR DESCRIPTION
This functionality would allow other programming languages to run this executable and get the waveform data directly without having to deal with filesystem or someone could use it to pipe the data to another command.

```
$ waveformjson song.wav --output
$ waveformjson song.wav --output | grep ...
```